### PR TITLE
Add example of trap command

### DIFF
--- a/bash.html.markdown
+++ b/bash.html.markdown
@@ -263,6 +263,10 @@ grep -c "^foo.*bar$" file.txt
 # and not the regex, use fgrep (or grep -F)
 fgrep "^foo.*bar$" file.txt
 
+# trap command allows you to execute a command when a signal is received by your script.
+# Here trap command will execute rm if any one of the three listed signals is received.
+trap "rm $TEMP_FILE; exit" SIGHUP SIGINT SIGTERM
+
 
 # Read Bash shell builtins documentation with the bash 'help' builtin:
 help


### PR DESCRIPTION
`trap` is a very important command to intercept a fatal signal, perform cleanup, and then exit gracefully. It needs an entry in this document.

Here a simple and most common example of using `trap` command i.e. cleanup upon receiving signal is added.
